### PR TITLE
Fix Binder examples with kotlin-numpy

### DIFF
--- a/binder/apt.txt
+++ b/binder/apt.txt
@@ -1,2 +1,2 @@
-openjdk-8-jre
-
+openjdk-8-jdk
+gcc

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -1,10 +1,9 @@
 name: kotlin-jupyter-demo
 dependencies:
-  - kotlin-jupyter-kernel>=0.8.0
+  - kotlin-jupyter-kernel>=0.8.1.98
   - python=3.7
-  - numpy
+  - numpy=1.18.5
 channels:
   - jetbrains
   - conda-forge
   - defaults
-

--- a/binder/start
+++ b/binder/start
@@ -1,0 +1,3 @@
+#!/bin/bash
+export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+exec "$@"


### PR DESCRIPTION
Fixed environment for Binder to launch kotlin-numpy samples